### PR TITLE
Mobile map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ before_install:
 script:
   - npm run build
   - npm test
+notifications:
+  email:
+    - tmikeschutte@gmail.com

--- a/src/App/Landing/_landing.scss
+++ b/src/App/Landing/_landing.scss
@@ -10,9 +10,9 @@
     a {
       width: 200px;
       margin: 0 5px;
+      background-color: rgba(256,256,256,.7);
       img {
         width: 100%;
-        background-color: rgba(256,256,256,.7);
         border-radius: 5px;
         transition: 600ms;
         &:hover, &:focus {
@@ -40,7 +40,14 @@
     .logos {
       background-color: rgba(250, 250, 250, .5);
       width: 100%;
-      flex-direction: column;
+      a {
+        width: 47%;
+        margin-bottom: 10px;
+        border-radius: 3px;
+        img {
+          width: 100%;
+        }
+      }
     }
 
     .video {

--- a/src/App/Map/Map.jsx
+++ b/src/App/Map/Map.jsx
@@ -14,6 +14,12 @@ const fetchActions = [
 ]
 
 class Map extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      sideVisible: false,
+    }
+  }
   componentDidMount() {
     fetchActions.forEach(a => this.props.actions[a](service))
   }
@@ -25,6 +31,7 @@ class Map extends Component {
 
     this.props.actions.addCurrentSuggestion(suggestion)
     this.props.actions.toggleSuggestionInfo(true)
+    this.toggleSideWrapper()
   }
 
   coordinatesCloseEnough = (suggestion, event) => (
@@ -40,12 +47,35 @@ class Map extends Component {
     )
   )
 
+  toggleSideWrapper = () => {
+    this.setState({
+      sideVisible: !this.state.sideVisible
+    })
+  }
+
+  get sideClass() {
+    return this.state.sideVisible
+      ? "visible" : "hidden"
+  }
+
+  get helperClass() {
+    return this.state.sideVisible
+      ? "open" : "closed"
+  }
+
+  scrollTop = () => {
+    window.scroll({
+      top: 0,
+      behavior: "smooth",
+    })
+  }
+
   render() {
     const categories = _.uniq(this.props.suggestions.map(s => s.category))
     const filteredSuggestions = this.filterPins(this.props.pinFilters, this.props.suggestions)
 
     const suggestionMapWrapper = (
-      <article>
+      <article className="suggestion-map">
         <SuggestionMapWrapper
           showSuggestionInfo={this.showSuggestionInfo}
           suggestions={filteredSuggestions}
@@ -56,7 +86,21 @@ class Map extends Component {
     return (
       <article className="map">
         { suggestionMapWrapper }
-        <SideWrapper categories={categories} />
+
+        <div
+          className="helper scroll"
+          onClick={this.scrollTop}
+        >
+          <i className="material-icons">arrow_upward</i>
+        </div>
+        <div
+          className={`helper side ${this.helperClass}`}
+          onClick={this.toggleSideWrapper}
+        >
+          <i className="material-icons">info</i>
+        </div>
+
+        <SideWrapper categories={categories} sideClass={this.sideClass} />
       </article>
     )
   }

--- a/src/App/Map/SideWrapper/Filters/Checkbox/Checkbox.jsx
+++ b/src/App/Map/SideWrapper/Filters/Checkbox/Checkbox.jsx
@@ -6,11 +6,14 @@ const Checkbox = ({ category, filterPins, pinFilters }) => (
   <article className="checkbox">
     <input 
       type="checkbox"
+      id={category || "all"}
       value={category}
-      onChange={event => filterPins(event)}
       checked={pinFilters.includes(category)}
+      onChange={event => filterPins(event)}
     />
-    <label>{ categoryLabels[category] }</label>
+    <label htmlFor={category || "all"}>
+      {categoryLabels[category]}
+    </label>
   </article>
 )
 

--- a/src/App/Map/SideWrapper/Filters/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/App/Map/SideWrapper/Filters/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -7,11 +7,14 @@ Array [
 >
     <input
         checked={false}
+        id="stay"
         onChange={[Function]}
         type="checkbox"
         value="stay"
     />
-    <label>
+    <label
+        htmlFor="stay"
+    >
         Places to Stay
     </label>
 </article>,

--- a/src/App/Map/SideWrapper/Filters/Checkbox/_checkbox.scss
+++ b/src/App/Map/SideWrapper/Filters/Checkbox/_checkbox.scss
@@ -1,18 +1,25 @@
 .checkboxes {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   @include map-info-border;
   padding: 0 1%;
   justify-content: space-between;
   >article {
-    width: 40%;
-  }
-
-  @media (max-width: 640px) {
-    font-size: .5em;
-    flex-direction: column;
-    >article {
-      width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    width: 100%;
+    article {
+      font-size: 1.5em;
+      margin: 10px 0;
+      width: 50%;
+      display: flex;
+      align-items: center;
+      label {
+        &:hover, &:focus {
+          cursor: pointer;
+        }
+      }
     }
   }
 }

--- a/src/App/Map/SideWrapper/Filters/FilterHelper/FilterHelper.js
+++ b/src/App/Map/SideWrapper/Filters/FilterHelper/FilterHelper.js
@@ -19,7 +19,7 @@ export const uncheck = (value: string, currentFilters: string[]): string[] => (
 
 export const check = (value: string, currentFilters: string[]): string[] => (
   value === "" || value === "DISPLAYNONE" ? (
-    [value] 
+    [value]
   ) : (
     currentFilters
       .filter(x => x !== "DISPLAYNONE" && x !== "")
@@ -29,6 +29,6 @@ export const check = (value: string, currentFilters: string[]): string[] => (
 
 const boxIsChecked = {
   true: uncheck,
-  false: check 
+  false: check
 }
 

--- a/src/App/Map/SideWrapper/Filters/FilterHelper/FilterHelper.spec.js
+++ b/src/App/Map/SideWrapper/Filters/FilterHelper/FilterHelper.spec.js
@@ -3,10 +3,10 @@ import * as FilterHelper from './FilterHelper'
 
 describe("FilterHelper methods", () => {
   describe("#filterPins", () => {
+    const event = { target: { value: "stay" } }
     describe("If the event target value is in the currentFilters array", () => {
       it("returns an array without that target value", () => {
         const currentFilters = ["places", "stay"]
-        const event = { target: { value: "stay" } }
         const expected = ["places"]
         expect(FilterHelper.filterPins(event, currentFilters)).toMatchObject(expected)
       })
@@ -15,7 +15,6 @@ describe("FilterHelper methods", () => {
     describe("If the event target value is not in the currentFilters array", () => {
       it("returns an array with that target value", () => {
         const currentFilters = ["places"]
-        const event = { target: { value: "stay" } }
         const expected = ["places", "stay"]
         expect(FilterHelper.filterPins(event, currentFilters)).toMatchObject(expected)
       })

--- a/src/App/Map/SideWrapper/Info/_info.scss
+++ b/src/App/Map/SideWrapper/Info/_info.scss
@@ -17,26 +17,4 @@
       text-align: center;
     }
   }
-  @media (max-width: 640px) {
-    padding: 1px;
-    line-height: 1.5em;
-    font-size: .5em;
-    text-align: left;
-    p {
-      &:nth-of-type(2) {
-        text-align: center;
-        margin: 10px 0;
-        span {
-          font-size: 1em;
-          text-decoration: underline;
-        }
-      }
-      &:nth-of-type(3) {
-        text-align: center;
-      }
-      &:nth-of-type(4) {
-        font-size: 8px;
-      }
-    }
-  }
 }

--- a/src/App/Map/SideWrapper/Legend/_legend.scss
+++ b/src/App/Map/SideWrapper/Legend/_legend.scss
@@ -29,25 +29,4 @@
       }
     }
   }
-
-  @media (max-width: 640px) {
-    h4 {
-      font-size: 1em;
-      width: 100%;
-    }
-    ul {
-      width: 100%;
-      li {
-        font-size: .5em;
-        margin-left: 2%;
-        &:nth-of-type(3) {
-          span {
-            color: #FB7064;
-            margin-left: 0;
-            margin-right: 0;
-          }
-        }
-      }
-    }
-  }
 }

--- a/src/App/Map/SideWrapper/SideWrapper.jsx
+++ b/src/App/Map/SideWrapper/SideWrapper.jsx
@@ -6,9 +6,9 @@ import Info from "./Info/Info"
 import SuggestionInfo from "./SuggestionInfo/SuggestionInfoContainer"
 import Filters from "./Filters/FiltersContainer"
 
-const SideWrapper = ({ categories })=> {
+const SideWrapper = ({ categories, sideClass })=> {
   return (
-    <section>
+    <section className={`side-wrapper ${sideClass}`}>
       <Legend categories={categories} />
       <SuggestionInfo />
       <Filters categories={categories} />
@@ -21,7 +21,8 @@ const SideWrapper = ({ categories })=> {
 }
 
 SideWrapper.propTypes = {
-  categories: PropTypes.array.isRequired
+  categories: PropTypes.array.isRequired,
+  sideClass: PropTypes.string.isRequired,
 }
 
 export default SideWrapper

--- a/src/App/Map/SideWrapper/SideWrapper.spec.js
+++ b/src/App/Map/SideWrapper/SideWrapper.spec.js
@@ -7,7 +7,8 @@ const props = {
   suggestionInfoIsActive: false,
   setFilters: function () {},
   pinFilters: [],
-  categories: []
+  categories: [],
+  sideClass: "visible",
 }
 
 describe("<SideWrapper />", () => {

--- a/src/App/Map/SideWrapper/SuggestionForm/_suggestion_form.scss
+++ b/src/App/Map/SideWrapper/SuggestionForm/_suggestion_form.scss
@@ -28,7 +28,7 @@
     }
     input {
       &[type="submit"] {
-        width: 25%;
+        width: 100%;
         align-self: center;
         background-color: $lilac;
         color: white;
@@ -44,31 +44,6 @@
   p {
     text-align: center;
     width: 100%;
-  }
-  @media (max-width: 640px) {
-    width: 100%;
-    font-size: 16px;
-    h4 {
-      font-size: 1em;
-    }
-    input, textarea, select {
-      font-size: .5em;
-    }
-    p {
-      font-size: .9em;
-    }
-    form {
-      font-size: .5em;
-      width: 90%;
-      input, textarea {
-        border: 1px solid #aaa;
-      }
-      input {
-        &[type="submit"] {
-          width: 100%;
-        }
-      }
-    }
   }
 }
 

--- a/src/App/Map/SideWrapper/SuggestionInfo/_suggestion_info.scss
+++ b/src/App/Map/SideWrapper/SuggestionInfo/_suggestion_info.scss
@@ -16,7 +16,5 @@
       }
     }
   }
-  @media (max-width: 640px) {
-    font-size: .5em;
-  }
 }
+

--- a/src/App/Map/SideWrapper/__snapshots__/SideWrapper.spec.js.snap
+++ b/src/App/Map/SideWrapper/__snapshots__/SideWrapper.spec.js.snap
@@ -2,7 +2,9 @@
 
 exports[`<SideWrapper /> snapshot is valid 1`] = `
 Array [
-  <section>
+  <section
+    className="side-wrapper visible"
+>
     <Connect(Legend)
         categories={Array []}
     />

--- a/src/App/Map/_map.scss
+++ b/src/App/Map/_map.scss
@@ -16,8 +16,6 @@ article.map {
   flex-flow: row wrap;
   font-size: 1em;
   color: #1a1a1a;
-  h4 {
-  }
   section {
     width: 40%;
     display: flex;
@@ -28,10 +26,54 @@ article.map {
       width: 100%;
     }
   }
+  .helper { display: none; }
   @media (max-width: 640px) {
+    .suggestion-map {
+      width: 100%;
+    }
     font-size: .8em;
-    section {
-      width: 30%;
+    .side-wrapper {
+      position: absolute;
+      z-index: 1;
+      right: 0;
+      transition: 300ms;
+      width: 100%;
+      overflow: scroll;
+    }
+    .hidden {
+      opacity: 0;
+      z-index: -1;
+    }
+    .visible {
+      opacity: 0.9;
+      background-color: #fff;
+    }
+    .helper {
+      border-radius: 50%;
+      width: 30px;
+      height: 30px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      position: fixed;
+      right: 5px;
+      color: #fff;
+      z-index: 2;
+    }
+    .side {
+      transition: 300ms;
+      &.closed {
+        background-color: $green;
+      }
+      &.open {
+        background-color: $blue;
+      }
+      top: 100px;
+    }
+    .scroll {
+      background-color: $yellow;
+      top: 65px;
     }
   }
 }

--- a/src/App/stylesheets/_base.scss
+++ b/src/App/stylesheets/_base.scss
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Cabin|Raleway');
+@import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 @import "./mixins.scss";
 
 

--- a/src/Redux/reducers/index.js
+++ b/src/Redux/reducers/index.js
@@ -25,7 +25,7 @@ const currentLocation = (state = {}, action) => (
   action.type === types.ADD_CURRENT_LOCATION ? action.data : state
 )
 
-const pinFilters = (state = [], action) => (
+const pinFilters = (state = ["DISPLAYNONE"], action) => (
   action.type === types.ADD_PIN_FILTERS ? action.data : state
 )
 

--- a/src/Redux/reducers/spec/pinFilters.spec.js
+++ b/src/Redux/reducers/spec/pinFilters.spec.js
@@ -6,7 +6,7 @@ describe("Reducers#pinFilters", () => {
     const expectedState = reducers(undefined, {})
     expect(expectedState).toMatchObject({
       map: {
-        pinFilters: []
+        pinFilters: ["DISPLAYNONE"]
       }
     })
   })
@@ -15,7 +15,7 @@ describe("Reducers#pinFilters", () => {
     const expectedState = reducers(undefined, { type: "SOMETHING_ELSE" })
     expect(expectedState).toMatchObject({
       map: {
-        pinFilters: []
+        pinFilters: ["DISPLAYNONE"]
       }
     })
   })


### PR DESCRIPTION
# Update

* Improves the mobile experience for the logos and map interactions.
* Sets default pin filter to "None" to reduce clutter.

## Logos

### Before

<img width="509" alt="screen shot 2017-10-22 at 10 15 47 pm" src="https://user-images.githubusercontent.com/19894032/31869531-b12cac40-b776-11e7-8f43-8967ee4c512a.png">

### After

<img width="509" alt="screen shot 2017-10-22 at 10 15 58 pm" src="https://user-images.githubusercontent.com/19894032/31869536-b645f3f8-b776-11e7-8660-63560364f030.png">

## Map

This adds two fixed helper buttons. One to toggle the map info and form, and one  to scroll to the top of the page.

### Before

<img width="508" alt="screen shot 2017-10-22 at 10 15 39 pm" src="https://user-images.githubusercontent.com/19894032/31869560-d82f72b4-b776-11e7-873c-55c11b6dec15.png">

### After

![after](https://user-images.githubusercontent.com/19894032/31889693-b8f4c8c4-b7ce-11e7-8b0c-523d306d8444.gif)
